### PR TITLE
Both manual and automated check for crypttab and root partition

### DIFF
--- a/controls/V-219150.rb
+++ b/controls/V-219150.rb
@@ -70,14 +70,18 @@ difficult because the existing partitions must be resized and changed.
   tag cci: ['V-100525', 'SV-109629', 'CCI-001199', 'CCI-002475', 'CCI-002476']
   tag nist: ['SC-28', 'SC-28 (1)', 'SC-28 (1)']
 
+  review_conditions = "Please review the partition layout to ensure 
+  all partitions other than the boot partition or pseudo file systems (such as
+  /proc or /sys) have a corresponding entry in /etc/crypttab"
+
   unless input('is_manual_nondefault_install_partition')
     describe command('sudo lsblk | grep -A3 `cat /etc/crypttab |cut -d" "  -f1` |grep root | awk "{print $NF}"') do
       its('exit_status') { should eq 0 }
       its('stdout.strip') { should eq '/' }
     end
   else
-    describe 'Manual test' do
-      skip 'This control must be reviewed manually'
+    describe review_conditions do
+      skip review_conditions
     end
   end
 end

--- a/controls/V-219150.rb
+++ b/controls/V-219150.rb
@@ -74,7 +74,7 @@ difficult because the existing partitions must be resized and changed.
   /proc or /sys) have a corresponding entry in /etc/crypttab"
 
   unless input('is_manual_nondefault_install_partition')
-    describe command('sudo lsblk | grep -A3 `cat /etc/crypttab |cut -d" "  -f1` |grep root | awk "{print $NF}"') do
+    describe command('sudo lsblk | grep -A3 `cat /etc/crypttab |cut -d" "  -f1` |grep root | awk \'{print $NF}\'') do
       its('exit_status') { should eq 0 }
       its('stdout.strip') { should eq '/' }
     end

--- a/controls/V-219150.rb
+++ b/controls/V-219150.rb
@@ -70,8 +70,7 @@ difficult because the existing partitions must be resized and changed.
   tag cci: ['V-100525', 'SV-109629', 'CCI-001199', 'CCI-002475', 'CCI-002476']
   tag nist: ['SC-28', 'SC-28 (1)', 'SC-28 (1)']
 
-  review_conditions = "Please review the partition layout to ensure 
-  all partitions other than the boot partition or pseudo file systems (such as
+  review_conditions = "all partitions other than the boot partition or pseudo file systems (such as
   /proc or /sys) have a corresponding entry in /etc/crypttab"
 
   unless input('is_manual_nondefault_install_partition')
@@ -80,8 +79,8 @@ difficult because the existing partitions must be resized and changed.
       its('stdout.strip') { should eq '/' }
     end
   else
-    describe review_conditions do
-      skip review_conditions
+    describe "Please review the partition layout to ensure #{review_conditions}" do
+      skip "Please review the partition layout to ensure #{review_conditions}"
     end
   end
 end

--- a/controls/V-219150.rb
+++ b/controls/V-219150.rb
@@ -69,5 +69,15 @@ difficult because the existing partitions must be resized and changed.
   tag fix_id: 'F-20874r304779_fix'
   tag cci: ['V-100525', 'SV-109629', 'CCI-001199', 'CCI-002475', 'CCI-002476']
   tag nist: ['SC-28', 'SC-28 (1)', 'SC-28 (1)']
-end
 
+  unless input('is_manual_nondefault_install_partition')
+    describe command('sudo lsblk | grep -A3 `cat /etc/crypttab |cut -d" "  -f1` |grep root | awk "{print $NF}"') do
+      its('exit_status') { should eq 0 }
+      its('stdout.strip') { should eq '/' }
+    end
+  else
+    describe 'Manual test' do
+      skip 'This control must be reviewed manually'
+    end
+  end
+end

--- a/inspec.yml
+++ b/inspec.yml
@@ -148,3 +148,9 @@ inputs:
     description: The length in seconds of inactivity for ClientAliveInterval in sshd_config
     type: String
     value: '600'   
+
+  # V-219150
+  - name: is_default_install_partition
+    description: Assert default partition layout for encryption
+    type: Boolean
+    value: false


### PR DESCRIPTION
The [16.04 check](https://github.com/mitre/canonical-ubuntu-16.04-lts-stig-baseline/blob/master/controls/V-75509.rb) was only manual but it is possible to compare cryttab to partition layout for default partition.  Made the default manual review still.