### PR TITLE
Update artifact actions to v4

### DIFF
--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Save our ${{ matrix.suite }} results summary
         continue-on-error: true
-        uses: mitre/saf_action@v1.5.0
+        uses: mitre/saf_action@v1
         with:
           command_string: 'view summary -j -i spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}.json -o spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}-data.json'
 
@@ -89,7 +89,7 @@ jobs:
           curl -# -s -F data=@spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}.json -F "filename=${{ env.COMMIT_SHORT_SHA }}-${{ env.PLATFORM }}_${{ matrix.suite }}" -F "public=true" -F "evaluationTags=${{ env.COMMIT_SHORT_SHA }},${{ github.repository }},${{ github.workflow }}" -H "Authorization: Api-Key ${{ secrets.SAF_HEIMDALL_UPLOAD_GROUP_KEY }}" "${{ vars.SAF_HEIMDALL_URL }}/evaluations"
 
       - name: Display our ${{ matrix.suite }} results summary
-        uses: mitre/saf_action@v1.5.0
+        uses: mitre/saf_action@v1
         with:
           command_string: 'view summary -i spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}.json'
 
@@ -102,6 +102,6 @@ jobs:
 
       - name: Ensure the scan meets our ${{ matrix.suite }} results threshold
         if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}
-        uses: mitre/saf_action@v1.5.0
+        uses: mitre/saf_action@v1
         with:
           command_string: 'validate threshold -i spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}.json -F ${{ matrix.suite }}.threshold.yml'

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -75,7 +75,7 @@ jobs:
         continue-on-error: true
         uses: mitre/saf_action@v1
         with:
-          command_string: 'view summary -j -i spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}.json -o spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}-data.json'
+          command_string: 'view summary -i spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}.json -o spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}-data.json'
 
       - name: Save Test Result JSON
         uses: actions/upload-artifact@v4

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -78,7 +78,7 @@ jobs:
           command_string: "view summary -j -i spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}.json -o spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}-data.json"
 
       - name: Save Test Result JSON
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ github.workflow }}-${{ env.COMMIT_SHORT_SHA }}-results
           path: spec/results/

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -14,11 +14,11 @@ jobs:
       CHEF_LICENSE: accept-silent
       CHEF_LICENSE_KEY: ${{ secrets.SAF_CHEF_LICENSE_KEY }}
       KITCHEN_LOCAL_YAML: kitchen.ec2.yml
-      PLATFORM: "ubuntu-18.04"
-      LC_ALL: "en_US.UTF-8"
+      PLATFORM: 'ubuntu-18.04'
+      LC_ALL: 'en_US.UTF-8'
     strategy:
       matrix:
-        suite: ["vanilla", "hardened"]
+        suite: ['vanilla', 'hardened']
       fail-fast: false
     steps:
       - name: add needed packages
@@ -29,7 +29,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.SAF_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.SAF_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
+          aws-region: ${{ secrets.SAF_AWS_REGION }}
 
       - name: Check out repository
         uses: actions/checkout@v4
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: '3.1'
 
       - name: Disable ri and rdoc
         run: 'echo "gem: --no-ri --no-rdoc" >> ~/.gemrc'
@@ -75,7 +75,7 @@ jobs:
         continue-on-error: true
         uses: mitre/saf_action@v1.5.0
         with:
-          command_string: "view summary -j -i spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}.json -o spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}-data.json"
+          command_string: 'view summary -j -i spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}.json -o spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}-data.json'
 
       - name: Save Test Result JSON
         uses: actions/upload-artifact@v4
@@ -91,7 +91,7 @@ jobs:
       - name: Display our ${{ matrix.suite }} results summary
         uses: mitre/saf_action@v1.5.0
         with:
-          command_string: "view summary -i spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}.json"
+          command_string: 'view summary -i spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}.json'
 
       - name: Generate Markdown Summary
         continue-on-error: true
@@ -104,4 +104,4 @@ jobs:
         if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}
         uses: mitre/saf_action@v1.5.0
         with:
-          command_string: "validate threshold -i spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}.json -F ${{ matrix.suite }}.threshold.yml"
+          command_string: 'validate threshold -i spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}.json -F ${{ matrix.suite }}.threshold.yml'

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -82,7 +82,7 @@ jobs:
         with:
           name: ${{ github.workflow }}-${{ env.COMMIT_SHORT_SHA }}-${{ matrix.suite }}-results
           path: spec/results/
-          overwrite: true
+
       - name: Upload ${{ matrix.suite }} to Heimdall
         continue-on-error: true
         run: |

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -104,4 +104,4 @@ jobs:
         if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}
         uses: mitre/saf_action@v1
         with:
-          command_string: 'validate threshold -i spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}.json -F ${{ matrix.suite }}.threshold.yml'
+          command_string: 'validate threshold -i spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}.json -T ${{ matrix.suite }}.threshold.yml'

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -80,9 +80,9 @@ jobs:
       - name: Save Test Result JSON
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.workflow }}-${{ env.COMMIT_SHORT_SHA }}-results
+          name: ${{ github.workflow }}-${{ env.COMMIT_SHORT_SHA }}-${{ matrix.suite }}-results
           path: spec/results/
-
+          overwrite: true
       - name: Upload ${{ matrix.suite }} to Heimdall
         continue-on-error: true
         run: |

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Upload ${{ matrix.suite }} to Heimdall
         continue-on-error: true
         run: |
-          curl -# -s -F data=@spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}.json -F "filename=${{ env.COMMIT_SHORT_SHA }}-${{ env.PLATFORM }}_${{ matrix.suite }}" -F "public=true" -F "evaluationTags=${{ env.COMMIT_SHORT_SHA }},${{ github.repository }},${{ github.workflow }}" -H "Authorization: Api-Key ${{ secrets.HEIMDALL_UPLOAD_GROUP_KEY }}" "${{ vars.SAF_HEIMDALL_URL }}/evaluations"
+          curl -# -s -F data=@spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}.json -F "filename=${{ env.COMMIT_SHORT_SHA }}-${{ env.PLATFORM }}_${{ matrix.suite }}" -F "public=true" -F "evaluationTags=${{ env.COMMIT_SHORT_SHA }},${{ github.repository }},${{ github.workflow }}" -H "Authorization: Api-Key ${{ secrets.SAF_HEIMDALL_UPLOAD_GROUP_KEY }}" "${{ vars.SAF_HEIMDALL_URL }}/evaluations"
 
       - name: Display our ${{ matrix.suite }} results summary
         uses: mitre/saf_action@v1.5.0


### PR DESCRIPTION
Changes made
- Updating artifact actions v3 to v4 since v3 will be deprecated 1/30/2025.
- Updated hardcoded AWS region to GitHub secret